### PR TITLE
Don't set PYTHONPATH in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,5 @@ language: python
 
 python: "3.3"
 
-before_install: export PYTHONPATH=$TRAVIS_BUILD_DIR
-
 script:
     - py.test


### PR DESCRIPTION
A tiny change, but this thingy isn't needed anymore...