### PR TITLE
Feature: allow a command to specify {module} in cmd parameters

### DIFF
--- a/python_test_plier.py
+++ b/python_test_plier.py
@@ -45,14 +45,15 @@ class RunPythonTestsCommand(sublime_plugin.WindowCommand):
         """ Convert a filename to a "module" relative to the working path """
         if not filename.endswith('.py'):
             _log('Cannot get module for non python-source file: ', filename)
-            return  # only pytnon modules are supported
+            return ''  # only pytnon modules are supported
         base = base or os.path.join(
-            self.window.extract_variables().get('project_path'),
-            self.window.extract_variables().get('project_base_name'))
+            self.window.extract_variables().get('project_path', ''),
+            self.window.extract_variables().get('project_base_name', ''))
         _log('Getting module for file %s relative to base %s' % (filename, base))
-        assert filename.startswith(base), (
-            'Cannot test file outside of given work directory')
-        return filename.replace(base, '').replace(os.path.sep, '.')[:-3]
+        if not filename.startswith(base):
+            _log('Cannot determine module path outside of directory')
+            return ''
+        return filename.replace(base, '').replace(os.path.sep, '.')[:-3].strip('.')
 
     def _get_default_kwargs(self):
         kwargs = {

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -106,3 +106,38 @@ class TestPlierCommand(TestCase):
         self.view.run_command("run_python_tests", **self.custom_kwargs)
         exec_cmd.assert_called_once_with(dict(
             working_dir='', env={}, cmd=['nosetests', '-k ']))
+
+    def test_custom_unittest_module_relative_to_project(self):
+        self.view.file_name = mock.Mock(return_value='/SublimeTestPlier/tests/file.py')
+        self.view.substr.return_value = self.mock_selection(2, 2)
+        custom_kwargs = self.custom_kwargs.copy()
+        custom_kwargs['cmd'] = ['unittest', '{module}.{test_class}.{test_func}']
+
+        # default: module relative to root of project
+        self.window.extract_variables.return_value = {
+            'project_path': '/',
+            'project_base_name': 'SublimeTestPlier',
+        }
+        self.view.run_command("run_python_tests", **custom_kwargs)
+        exec_cmd.assert_called_once_with(dict(
+            working_dir='', env={},
+            cmd=['unittest', 'tests.file.TestCase.test_fail', ]))
+
+    def test_custom_unittest_module_relative_to_working_dir(self):
+        self.view.file_name = mock.Mock(return_value='/SublimeTestPlier/tests/file.py')
+        self.view.substr.return_value = self.mock_selection(2, 2)
+        custom_kwargs = self.custom_kwargs.copy()
+        custom_kwargs['cmd'] = ['unittest', '{module}.{test_class}.{test_func}']
+
+        # default: module relative to root of project
+        self.window.extract_variables.return_value = {
+            'project_path': '/',
+            'project_base_name': 'SublimeTestPlier',
+        }
+
+        # custom: module relative to the specified working dir in build system
+        custom_kwargs['working_dir'] = '/SublimeTestPlier/tests/'
+        self.view.run_command("run_python_tests", **custom_kwargs)
+        exec_cmd.assert_called_once_with(dict(
+            working_dir='/SublimeTestPlier/tests/', env={},
+            cmd=['unittest', 'file.TestCase.test_fail', ]))

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -8,7 +8,17 @@ import sublime
 
 from ..test_parser import TestParser
 
-DEBUG = False
+
+@property
+def DEBUG():
+    settings = sublime.load_settings("test_plier.sublime-settings")
+    return settings.get('debug')
+
+
+@DEBUG.setter
+def DEBUG(value):
+    settings = sublime.load_settings("test_plier.sublime-settings")
+    settings['debug'] = value
 
 
 def _log(*args, **kwargs):


### PR DESCRIPTION
- This is, for instance, used by unittest to specify a given module
  to test, rather than a filename as on pytest

  Here is an example for CPython core Lib test build system:

```json
{
    "cmd": ["/Users/pavel/dev/github/cpython/python.exe",
            "-m", "unittest",  "-v", "{module}.{test_class}.{test_func}"],
    "working_dir": "/Users/pavel/dev/github/cpython/Lib/",
    "target": "run_python_tests",
    "name": "TestLibrary",
}
```